### PR TITLE
Update custom-template.js

### DIFF
--- a/components/data/datatable/mixins/custom-template.js
+++ b/components/data/datatable/mixins/custom-template.js
@@ -1,7 +1,7 @@
 export default {
   methods: {
     hasCustomTemplate: function (col) {
-      return Boolean(this.$scopedSlots[col.prop] || this.$scopedSlots[col.slot])
+      return Boolean(this.$scopedSlots[col.slot])
     }
   }
 }

--- a/components/data/datatable/mixins/custom-template.js
+++ b/components/data/datatable/mixins/custom-template.js
@@ -1,7 +1,7 @@
 export default {
   methods: {
     hasCustomTemplate: function (col) {
-      return Boolean(this.$scopedSlots[col.prop])
+      return Boolean(this.$scopedSlots[col.prop] || this.$scopedSlots[col.slot])
     }
   }
 }


### PR DESCRIPTION
Datatable is disregarding all of the custom templates with a defined namespace through the column.slot property.